### PR TITLE
fix(notebook): Resolve input flickering by optimizing render logic

### DIFF
--- a/window/components/apps/NotebookApp.tsx
+++ b/window/components/apps/NotebookApp.tsx
@@ -145,10 +145,9 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
     const textarea = textareaRef.current;
     if (!textarea) return;
 
-    const {selectionStart, selectionEnd} = textarea;
+    const {value, selectionStart, selectionEnd} = textarea;
     const selectedCount = selectionEnd - selectionStart;
-    const cursorPosition = textarea.selectionStart;
-    const textBeforeCursor = content.substring(0, cursorPosition);
+    const textBeforeCursor = value.substring(0, selectionStart);
     const lines = textBeforeCursor.split('\n');
     const currentLineNumber = lines.length;
     const currentColumnNumber = lines[lines.length - 1].length + 1;
@@ -156,14 +155,14 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
     setStatusBarInfo({
       line: currentLineNumber,
       column: currentColumnNumber,
-      charCount: content.length,
+      charCount: value.length,
       selectedCount: selectedCount,
     });
-  }, [content]);
+  }, []);
 
   useEffect(() => {
     updateStatusBar();
-  }, [content, updateStatusBar]);
+  }, [content]);
 
   const handleContentChange = (newContent: string) => {
     setContent(newContent);
@@ -295,8 +294,10 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
       <textarea
         ref={textareaRef}
         value={isLoading ? 'Loading...' : content}
-        onChange={e => handleContentChange(e.target.value)}
-        onKeyUp={updateStatusBar}
+        onChange={e => {
+          handleContentChange(e.target.value);
+          updateStatusBar();
+        }}
         onMouseUp={updateStatusBar}
         onClick={updateStatusBar}
         onSelect={updateStatusBar}


### PR DESCRIPTION
The user reported a severe flickering issue in the Notebook application that made it impossible to input text.

The root cause was a re-render loop. The `updateStatusBar` function depended on the `content` state, causing it to be recreated on every keystroke. A `useEffect` hook also depended on this unstable function, triggering a state update for the status bar, which in turn caused another re-render.

This patch refactors the update logic to be more efficient:
- The `updateStatusBar` function is now a stable `useCallback` with no dependencies, reading directly from the textarea's DOM element to get its data.
- The state updates for content and the status bar are now consolidated within the `textarea`'s `onChange` event handler. This allows React to batch the updates into a single render per keystroke.
- The redundant `onKeyUp` handler is removed, and the `useEffect` is kept only for handling programmatic content changes (e.g., file loads).

This resolves the flickering issue and improves the overall performance of the component.