### PR TITLE
fix(notebook): Resolve input flickering by removing render loop

### DIFF
--- a/window/components/apps/NotebookApp.tsx
+++ b/window/components/apps/NotebookApp.tsx
@@ -160,9 +160,6 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
     });
   }, []);
 
-  useEffect(() => {
-    updateStatusBar();
-  }, [content]);
 
   const handleContentChange = (newContent: string) => {
     setContent(newContent);
@@ -294,10 +291,8 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
       <textarea
         ref={textareaRef}
         value={isLoading ? 'Loading...' : content}
-        onChange={e => {
-          handleContentChange(e.target.value);
-          updateStatusBar();
-        }}
+        onChange={e => handleContentChange(e.target.value)}
+        onKeyUp={updateStatusBar}
         onMouseUp={updateStatusBar}
         onClick={updateStatusBar}
         onSelect={updateStatusBar}


### PR DESCRIPTION
The user reported a severe flickering issue in the Notebook application that made it impossible to input text. The root cause was a re-render loop triggered on every keystroke.

The previous logic used a `useEffect` hook that depended on the `content` state. This effect would call a function to update the status bar, which set another state variable, triggering a second render and causing a loop that made the UI unresponsive.

This patch implements a safer fix by completely removing the re-render loop:
- The `updateStatusBar` function is now a stable `useCallback` with no dependencies. It reads data directly from the textarea's DOM element via a ref, ensuring it always has the latest information without needing to depend on state.
- The `useEffect` hook that caused the loop has been deleted.
- Status bar updates on user input are now handled by existing event handlers (`onKeyUp`, `onClick`, etc.) which call the stable `updateStatusBar` function.

This change completely resolves the critical input flickering bug.

As a trade-off, this simpler design means the status bar will not automatically update after a file is loaded. It will update as soon as the user interacts with the textarea (e.g., clicks or types). This is a minor regression in functionality that is accepted in order to restore the core usability of the application.