### PR TITLE
fix(notebook): Fix flashing and remounting on input

### DIFF
--- a/window/components/apps/NotebookApp.tsx
+++ b/window/components/apps/NotebookApp.tsx
@@ -291,8 +291,10 @@ const NotebookApp: React.FC<AppComponentProps> = ({setTitle, initialData}) => {
       <textarea
         ref={textareaRef}
         value={isLoading ? 'Loading...' : content}
-        onChange={e => handleContentChange(e.target.value)}
-        onKeyUp={updateStatusBar}
+        onChange={e => {
+          handleContentChange(e.target.value);
+          updateStatusBar();
+        }}
         onMouseUp={updateStatusBar}
         onClick={updateStatusBar}
         onSelect={updateStatusBar}

--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -15,6 +15,10 @@ export const useWindowManager = (
   desktopRef: React.RefObject<HTMLDivElement>,
 ) => {
   const [openApps, setOpenApps] = useState<OpenApp[]>([]);
+  const openAppsRef = useRef(openApps);
+  useEffect(() => {
+    openAppsRef.current = openApps;
+  }, [openApps]);
   const [activeAppInstanceId, setActiveAppInstanceId] = useState<string | null>(
     null,
   );
@@ -133,14 +137,14 @@ export const useWindowManager = (
 
       // If multiple instances are not allowed, check for an existing instance
       if (!appDef.allowMultipleInstances && !initialData) {
-        const existingAppInstance = openApps.find(
+        const existingAppInstance = openAppsRef.current.find(
           app => app.id === appDef!.id && !app.isMinimized,
         );
         if (existingAppInstance) {
           focusApp(existingAppInstance.instanceId);
           return;
         }
-        const minimizedInstance = openApps.find(
+        const minimizedInstance = openAppsRef.current.find(
           app => app.id === appDef!.id && app.isMinimized,
         );
         if (minimizedInstance) {
@@ -172,7 +176,7 @@ export const useWindowManager = (
       setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
       setActiveAppInstanceId(instanceId);
     },
-    [appDefinitions, nextZIndex, openApps],
+    [appDefinitions, nextZIndex, focusApp, toggleMinimizeApp],
   );
 
   const focusApp = useCallback(
@@ -218,7 +222,7 @@ export const useWindowManager = (
 
   const toggleMinimizeApp = useCallback(
     (instanceId: string) => {
-      const app = openApps.find(a => a.instanceId === instanceId);
+      const app = openAppsRef.current.find(a => a.instanceId === instanceId);
       if (!app) return;
 
       setOpenApps(prev =>
@@ -236,7 +240,7 @@ export const useWindowManager = (
         setActiveAppInstanceId(null);
       }
     },
-    [openApps, activeAppInstanceId, focusApp],
+    [activeAppInstanceId, focusApp],
   );
 
   const toggleMaximizeApp = useCallback(


### PR DESCRIPTION
This commit resolves a critical bug in the Notebook application where typing would cause severe flashing and, in some cases, a full component remount, making the app unusable.

The issue was traced to two separate but related problems:

1.  **Window Manager Instability (Remounting Bug):** A dependency cycle existed in the `useWindowManager` hook. When the Notebook's title was updated (e.g., to add a dirty indicator `*`), it triggered a state update on the `openApps` array. Core functions like `openApp` and `toggleMinimizeApp` depended on this `openApps` state, causing them to be recreated on every title change. This unstable function was passed down as a prop, leading to the entire `NotebookApp` component remounting, which reset its state and showed a "Loading..." message.

    This is fixed by introducing a `useRef` (`openAppsRef`) to hold a stable reference to the `openApps` array. The core functions now read from this ref, breaking the dependency cycle and ensuring they are stable.

2.  **Inefficient Rendering (Flashing Bug):** The original flickering was caused by a double-render on every keystroke within `NotebookApp`. The `onChange` event would set the content state, and a separate `onKeyUp` event would set the status bar state.

    This is fixed by consolidating both state updates into the `onChange` event handler. This allows React to batch the updates into a single, efficient render per keystroke. The `updateStatusBar` function was also made stable by reading from the textarea's ref instead of depending on state.

By fixing both the underlying state management architecture and the component-level rendering logic, this commit ensures the Notebook application is both stable and responsive during user input.