### PR TITLE
Fix bug causing input to be erased in Notebook app

### DIFF
--- a/window/App.tsx
+++ b/window/App.tsx
@@ -42,7 +42,15 @@ const App: React.FC = () => {
 
   // A simple way to trigger refresh in filesystem-aware components
   const [refreshId, setRefreshId] = useState(0);
-  const triggerRefresh = () => setRefreshId(id => id + 1);
+  const triggerRefresh = useCallback(() => setRefreshId(id => id + 1), []);
+
+  const commonData = useMemo(
+    () => ({
+      refreshId,
+      triggerRefresh,
+    }),
+    [refreshId, triggerRefresh],
+  );
 
   const toggleStartMenu = useCallback(
     () => setIsStartMenuOpen(prev => !prev),
@@ -119,14 +127,8 @@ const App: React.FC = () => {
                   .map(app => (
                     <AppWindow
                       key={app.instanceId}
-                      app={{
-                        ...app,
-                        initialData: {
-                          ...app.initialData,
-                          refreshId,
-                          triggerRefresh,
-                        },
-                      }}
+                      app={app}
+                      commonData={commonData}
                       onClose={() => closeApp(app.instanceId)}
                       onMinimize={() => toggleMinimizeApp(app.instanceId)}
                       onMaximize={() => toggleMaximizeApp(app.instanceId)}

--- a/window/components/AppWindow.tsx
+++ b/window/components/AppWindow.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef, useCallback} from 'react';
+import React, {useState, useEffect, useRef, useCallback, useMemo} from 'react';
 import {OpenApp, ClipboardItem, FilesystemItem} from '../types';
 import {DiscoveredAppDefinition} from '../contexts/AppContext';
 import {TASKBAR_HEIGHT} from '../constants';
@@ -7,6 +7,10 @@ import Icon from './icon';
 
 interface AppWindowProps {
   app: OpenApp;
+  commonData: {
+    refreshId: number;
+    triggerRefresh: () => void;
+  };
   onClose: () => void;
   onMinimize: () => void;
   onMaximize: () => void;
@@ -26,6 +30,7 @@ interface AppWindowProps {
 
 const AppWindow: React.FC<AppWindowProps> = ({
   app,
+  commonData,
   onClose,
   onMinimize,
   onMaximize,
@@ -306,7 +311,10 @@ const AppWindow: React.FC<AppWindowProps> = ({
             app.id === 'themes' ? onWallpaperChange : undefined
           }
           openApp={openApp}
-          initialData={app.initialData}
+          initialData={useMemo(
+            () => ({...app.initialData, ...commonData}),
+            [app.initialData, commonData],
+          )}
           clipboard={clipboard}
           handleCopy={handleCopy}
           handleCut={handleCut}


### PR DESCRIPTION
The Notebook application had a bug where typed characters would appear for a moment and then disappear. This was caused by an issue in React state management.

The root cause was that the `initialData` prop being passed to the Notebook component was being recreated on every render of its parent component. This happened whenever any state in the parent changed, such as when the Notebook's window title was updated to show an unsaved state ('*').

When the `initialData` prop received a new object reference, a `useEffect` hook inside the Notebook app would re-run, causing it to reload its initial state and discard the user's input.

This was fixed by refactoring how props are passed from `App.tsx` to `AppWindow.tsx`. The `initialData` is now constructed using `useMemo` in `AppWindow.tsx` from stable, memoized props passed down from `App.tsx`. This ensures that the `initialData` object reference remains stable across re-renders, unless its underlying data actually changes, thus preventing the bug.