### PR TITLE
Fixup: Correct React Hook usage and fix Notebook input bug

### DIFF
--- a/window/components/AppWindow.tsx
+++ b/window/components/AppWindow.tsx
@@ -64,6 +64,14 @@ const AppWindow: React.FC<AppWindowProps> = ({
   const windowRef = useRef<HTMLDivElement>(null);
   const {theme} = useTheme();
 
+  const memoizedInitialData = useMemo(
+    () => ({
+      ...app.initialData,
+      ...commonData,
+    }),
+    [app.initialData, commonData],
+  );
+
   const handleMouseDownHeader = (e: React.MouseEvent<HTMLDivElement>) => {
     if (app.isMaximized || isResizing) return;
     if ((e.target as HTMLElement).closest('button')) return;
@@ -311,10 +319,7 @@ const AppWindow: React.FC<AppWindowProps> = ({
             app.id === 'themes' ? onWallpaperChange : undefined
           }
           openApp={openApp}
-          initialData={useMemo(
-            () => ({...app.initialData, ...commonData}),
-            [app.initialData, commonData],
-          )}
+          initialData={memoizedInitialData}
           clipboard={clipboard}
           handleCopy={handleCopy}
           handleCut={handleCut}


### PR DESCRIPTION
This commit resolves two issues.

First, it fixes a critical bug that caused the application to crash with a black screen. This was due to a violation of the Rules of Hooks, where `useMemo` was called incorrectly inside of the JSX render block in `AppWindow.tsx`. This commit moves the `useMemo` call to the top level of the component, resolving the crash.

Second, it fixes the original bug where user input in the Notebook app would disappear. This was caused by an unstable `initialData` prop forcing the component to re-initialize its state. This is resolved by carefully memoizing props using `useCallback` and `useMemo` in `App.tsx` and `AppWindow.tsx` to ensure the `initialData` prop reference remains stable across non-related state updates.